### PR TITLE
Fix system.new.dat extraction error (on Ubuntu16LTS)

### DIFF
--- a/Xtrakt
+++ b/Xtrakt
@@ -125,6 +125,7 @@ st_flicx(){
 #converting to system image
 #--------------------------
 UnPck(){
+sudo mkdir $PROJECT_DIR/convert-dat/out
 printf '\e[8;33;80t]'
 $permsda
 clear


### PR DESCRIPTION
Its strange but this is the only fix which works for me.
> mount: mount point convert-dat/out/ does not exist.

![screenshot from 2017-11-16 13-12-15](https://user-images.githubusercontent.com/22051980/32878553-b475f772-cad0-11e7-8550-705ef25c2658.png)
